### PR TITLE
Fix KillAura & Reach Problem

### DIFF
--- a/src/Modules/Killaura.php
+++ b/src/Modules/Killaura.php
@@ -147,7 +147,7 @@ class Killaura extends Zuri implements Listener {
 				}
 			}
 			if (!isset($entities[$entity->getId()])) {
-				$this->fail($player);
+				$this->fail($damager);
 			}
 		}
 	}

--- a/src/Modules/Reach.php
+++ b/src/Modules/Reach.php
@@ -70,7 +70,6 @@ class Reach extends Zuri implements Listener {
 	// V2 - just check again...
 	public function reachV2(EntityDamageEvent $event) {
 		if ($event instanceof EntityDamageByEntityEvent && $event->getEntity() instanceof Player && $event->getDamager() instanceof Player) {
-			// Use $event->getDamager() instead of $damager
 			if ($this->canBypass($event->getDamager())) {
 				return;
 			}
@@ -94,7 +93,6 @@ class Reach extends Zuri implements Listener {
 	// V3 - just checking again
 	public function reachV3(EntityDamageEvent $event) {
 		if ($event instanceof EntityDamageByEntityEvent && $event->getEntity() instanceof Player && $event->getDamager() instanceof Player) {
-			// Use $event->getDamager() instead of $damager
 			if ($this->canBypass($event->getDamager())) {
 				return;
 			}

--- a/src/Modules/Reach.php
+++ b/src/Modules/Reach.php
@@ -70,10 +70,11 @@ class Reach extends Zuri implements Listener {
 	// V2 - just check again...
 	public function reachV2(EntityDamageEvent $event) {
 		if ($event instanceof EntityDamageByEntityEvent && $event->getEntity() instanceof Player && $event->getDamager() instanceof Player) {
-			if ($this->canBypass($damager)) {
+			// Use $event->getDamager() instead of $damager
+			if ($this->canBypass($event->getDamager())) {
 				return;
 			}
-			if ($this->isLagging($damager)) {
+			if ($this->isLagging($event->getDamager())) {
 				return;
 			}
 			if ($event->getDamager()->getGamemode()->equals(GameMode::CREATIVE())) {
@@ -93,10 +94,11 @@ class Reach extends Zuri implements Listener {
 	// V3 - just checking again
 	public function reachV3(EntityDamageEvent $event) {
 		if ($event instanceof EntityDamageByEntityEvent && $event->getEntity() instanceof Player && $event->getDamager() instanceof Player) {
-			if ($this->canBypass($damager)) {
+			// Use $event->getDamager() instead of $damager
+			if ($this->canBypass($event->getDamager())) {
 				return;
 			}
-			if ($this->isLagging($damager)) {
+			if ($this->isLagging($event->getDamager())) {
 				return;
 			}
 			if (!$event->getDamager()->canInteract($event->getEntity()->getLocation()->add(0.5, 0.5, 0.5), $event->getEntity()->isCreative() ? Anticheat::getInstance()->getConfig()->getNested("max-reach-distance-creative", Reach::MAX_REACH_DISTANCE_CREATIVE_V3) : Anticheat::getInstance()->getConfig()->getNested("max-reach-distance-survival", Reach::MAX_REACH_DISTANCE_SURVIVAL_V3))) {


### PR DESCRIPTION
KillAura Problem:
[18:41:05.686] [Server thread/EMERGENCY]: Crash occurred while handling a packet from session: PlayerName
[18:41:05.687] [Server thread/CRITICAL]: ErrorException: "Undefined variable $player" (EXCEPTION) in "plugins/Zuri/src/Modules/Killaura" at line 132
Reach Problem:
[18:31:16.823] [Server thread/EMERGENCY]: Crash occurred while handling a packet from session: PlayerName
[18:31:16.824] [Server thread/CRITICAL]: ErrorException: "Undefined variable $damager" (EXCEPTION) in "plugins/Zuri/src/Modules/Reach" at line 55
